### PR TITLE
Add deletion when player answers twice

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -489,6 +489,7 @@ client.on('messageCreate', async message => {
         if (message.author.id === lastPlayerId) {
             message.react('❌')
             sendAutoDeleteMessageToChannel('Bạn đã trả lời lượt trước rồi, hãy đợi đối thủ!', configChannel)
+            if (message.deletable) message.delete().catch(() => {})
             return
         }
     }


### PR DESCRIPTION
## Summary
- delete a player's message if they try to answer twice in a row

## Testing
- `yarn test` *(fails: package missing in lockfile)*
- `yarn install` *(fails: network 403)*

------
https://chatgpt.com/codex/tasks/task_e_6878a1b624348324a2a32e0c614b3b3c